### PR TITLE
remove 64 bit division for RPi

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -491,8 +491,13 @@ static int emu3_add_file_dentry(struct inode *dir, struct dentry *dentry,
 	return err;
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 12, 0)
 static int emu3_create(struct user_namespace *mnt_userns, struct inode *dir,
 		       struct dentry *dentry, umode_t mode, bool excl)
+#else
+static int emu3_create(struct inode *dir,
+		       struct dentry *dentry, umode_t mode, bool excl)
+#endif
 {
 	int err;
 	unsigned int dnum;
@@ -522,7 +527,11 @@ static int emu3_create(struct user_namespace *mnt_userns, struct inode *dir,
 		goto end;
 	}
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 12, 0)
 	inode_init_owner(&init_user_ns, inode, dir, mode);
+#else
+	inode_init_owner(inode, dir, mode);
+#endif
 	inode->i_mtime = inode->i_atime = inode->i_ctime = current_time(inode);
 	inode->i_blocks = info->blocks_per_cluster;
 	inode->i_op = &emu3_inode_operations_file;
@@ -693,9 +702,15 @@ static int emu3_unlink(struct inode *dir, struct dentry *dentry)
 	return 0;
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 12, 0)
 static int emu3_rename(struct user_namespace *mnt_userns, struct inode *old_dir,
 		       struct dentry *old_dentry, struct inode *new_dir,
 		       struct dentry *new_dentry, unsigned int flags)
+#else
+static int emu3_rename(struct inode *old_dir,
+		       struct dentry *old_dentry, struct inode *new_dir,
+		       struct dentry *new_dentry, unsigned int flags)
+#endif
 {
 	int err = 0;
 	unsigned char id;
@@ -788,8 +803,13 @@ static int emu3_rename(struct user_namespace *mnt_userns, struct inode *old_dir,
 	return err;
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 12, 0)
 static int emu3_mkdir(struct user_namespace *mnt_userns, struct inode *dir,
 		      struct dentry *dentry, umode_t mode)
+#else
+static int emu3_mkdir(struct inode *dir,
+		      struct dentry *dentry, umode_t mode)
+#endif
 {
 	int err;
 	unsigned int dnum;
@@ -816,7 +836,11 @@ static int emu3_mkdir(struct user_namespace *mnt_userns, struct inode *dir,
 		return err;
 	}
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 12, 0)
 	inode_init_owner(&init_user_ns, inode, dir, EMU3_DIR_MODE);
+#else
+	inode_init_owner(inode, dir, EMU3_DIR_MODE);
+#endif
 	inode->i_blocks = 1;
 	inode->i_op = &emu3_inode_operations_dir;
 	inode->i_fop = &emu3_file_operations_dir;

--- a/emu3_fs.h
+++ b/emu3_fs.h
@@ -30,7 +30,8 @@
 #define EMU3_FS_SIGNATURE "EMU3"
 #define EMU3_FS_TYPE 0x454d5533
 
-#define EMU3_BSIZE 0x200
+#define EMU3_BSIZE_BITS 9
+#define EMU3_BSIZE (1 << EMU3_BSIZE_BITS)
 #define EMU3_CLUSTER_ENTRIES_PER_BLOCK  (EMU3_BSIZE >> 1)
 
 #define EMU3_I_ID_ROOT_DIR 1	//Any value is valid as long as is lower than the first inode ID.
@@ -115,7 +116,7 @@ struct emu3_sb_info {
 	unsigned int start_data_block;
 	unsigned int blocks_per_cluster;
 	unsigned int clusters;
-	unsigned int bytes_per_cluster;	//This is quite convenient.
+	unsigned char cluster_size_shift; //Cluster size always a power of 2
 	short *cluster_list;
 	bool *dir_content_block_list;
 	unsigned int *i_maps;

--- a/emu3_fs.h
+++ b/emu3_fs.h
@@ -24,6 +24,7 @@
 #include <linux/string.h>
 #include <linux/vfs.h>
 #include <linux/writeback.h>
+#include <linux/version.h>
 
 #define EMU3_MODULE_NAME "emu3fs"
 

--- a/file.c
+++ b/file.c
@@ -103,8 +103,12 @@ static sector_t emu3_bmap(struct address_space *mapping, sector_t block)
 	return generic_block_bmap(mapping, block, emu3_get_block);
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 12, 0)
 static int emu3_setattr(struct user_namespace *mnt_userns,
 			struct dentry *dentry, struct iattr *attr)
+#else
+static int emu3_setattr(struct dentry *dentry, struct iattr *attr)
+#endif
 {
 	struct inode *inode = d_inode(dentry);
 	struct emu3_sb_info *info = EMU3_SB(inode->i_sb);
@@ -112,7 +116,11 @@ static int emu3_setattr(struct user_namespace *mnt_userns,
 	blkcnt_t blocks;
 	int err;
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 12, 0)
 	err = setattr_prepare(&init_user_ns, dentry, attr);
+#else
+	err = setattr_prepare(dentry, attr);
+#endif
 	if (err)
 		return err;
 
@@ -131,7 +139,11 @@ static int emu3_setattr(struct user_namespace *mnt_userns,
 		inode->i_blocks = blocks;
 	}
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 12, 0)
 	setattr_copy(&init_user_ns, inode, attr);
+#else
+	setattr_copy(inode, attr);
+#endif
 	mark_inode_dirty(inode);
 
 	return 0;

--- a/super.c
+++ b/super.c
@@ -73,11 +73,11 @@ void emu3_set_fattrs(struct emu3_sb_info *info,
 		fattrs->blocks = cpu_to_le16(1);
 		fattrs->bytes = cpu_to_le16(0);
 	} else {
-		fattrs->clusters = size / info->bytes_per_cluster;
-		rem = size % info->bytes_per_cluster;
+		fattrs->clusters = size >> info->cluster_size_shift;
+		rem = size - (fattrs->clusters << info->cluster_size_shift);
 		if (rem)
 			fattrs->clusters++;
-		fattrs->blocks = rem / EMU3_BSIZE;
+		fattrs->blocks = rem >> EMU3_BSIZE_BITS;
 		rem = rem % EMU3_BSIZE;
 		if (rem)
 			fattrs->blocks++;
@@ -513,8 +513,8 @@ static int emu3_fill_super(struct super_block *sb, void *data,
 	info->start_cluster_list_block = le32_to_cpu(parameters[6]);
 	info->cluster_list_blocks = le32_to_cpu(parameters[7]);
 	info->start_data_block = le32_to_cpu(parameters[8]);
-	info->blocks_per_cluster = (0x10000 << (e3sb[0x28] - 1)) / EMU3_BSIZE;
-	info->bytes_per_cluster = info->blocks_per_cluster * EMU3_BSIZE;
+	info->cluster_size_shift = 15 + e3sb[0x28];	//32kB minimum
+	info->blocks_per_cluster = 1 << (info->cluster_size_shift - EMU3_BSIZE_BITS);
 	//In Formula 4000 only, the total amount of blocks and clusters would allow to have a disk bigger than the ISO image itself.
 	//Thus, the reported amount of blocks, size and free space is not right.
 	//However, if the iso image is resized to accommodate all the blocks, the format is valid and stat and df output the right values.

--- a/xattr.c
+++ b/xattr.c
@@ -49,11 +49,18 @@ static int emu3_xattr_get(const struct xattr_handler *handler,
 	return ret;
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 12, 0)
 static int emu3_xattr_set(const struct xattr_handler *handler,
 			  struct user_namespace *mnt_userns,
 			  struct dentry *dentry, struct inode *inode,
 			  const char *name, const void *buffer, size_t size,
 			  int flags)
+#else
+static int emu3_xattr_set(const struct xattr_handler *handler,
+			  struct dentry *dentry, struct inode *inode,
+			  const char *name, const void *buffer, size_t size,
+			  int flags)
+#endif
 {
 	long bn;
 	int ret;


### PR DESCRIPTION
This commit removes a 64 bit division which is problematic on the RPi kernel.  The code relies on `clusters_per_block` (and the now obsolete `bytes_per_block`) being a power of 2, and replaces the division with bit shifts instead.

NB: The RaSCSI project is using Linux 5.10, and the commit to `master` that add the `user_namespace` parameters make the code backwards incompatible.   This PR is therefore forked from two commits earlier (9d8fe7160481c604bd062c4b0663ad9843a014dc)